### PR TITLE
Include HISTORY and README file in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,8 @@ include requirements.txt
 include test_requirements.txt
 include translate/etc/supported_translations.json
 include version.py
+include HISTORY.rst
+include README.rst
 
 recursive-include translate *.py
 recursive-exclude texts *


### PR DESCRIPTION
setup.py requires both of those packages, without them, it's impossible
to install py-translate from tar.gz package

Fixes #8 